### PR TITLE
Use DeserializeOwned in AuthKeyExchange trait as opposed to HRTB.

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,13 +1,13 @@
 use rand::{ Rng, CryptoRng };
-use serde::{ Serialize, Deserialize };
+use serde::{ Serialize, de::DeserializeOwned };
 use crate::Envelope;
 
 
 pub trait AuthKeyExchange {
-    type PrivateKey: Serialize + for<'a> Deserialize<'a>;
-    type PublicKey: Serialize + for<'a> Deserialize<'a> + Clone;
-    type EphemeralKey: Serialize + for<'a> Deserialize<'a>;
-    type Message: Serialize + for<'a> Deserialize<'a> + Clone;
+    type PrivateKey: Serialize + DeserializeOwned;
+    type PublicKey: Serialize + DeserializeOwned + Clone;
+    type EphemeralKey: Serialize + DeserializeOwned;
+    type Message: Serialize + DeserializeOwned + Clone;
 
     const SHARED_LENGTH: usize;
 


### PR DESCRIPTION
This project currently fails to compile on nightly (rustc 1.33.0) due to a compiler bug detailed [here](https://github.com/rust-lang/rust/issues/57639). This fix uses nicer syntax and also skirts around the bug with no added overhead.